### PR TITLE
Valid email password

### DIFF
--- a/QTMAProject/src/screens/Authentication/AuthForm.js
+++ b/QTMAProject/src/screens/Authentication/AuthForm.js
@@ -174,7 +174,7 @@ export default withFormik({
     }
 
     if (values.rePWD != values.password){
-      errors.rePWD = 'Passwords must match'
+      errors.rePWD = 'Passwords must match' // must check if passwords match
     }
     return errors;
   },


### PR DESCRIPTION
Not much added here, just displaying error messages to the user on the signup page using the <Text> tags. We check if the email is valid (i.e. has the @ symbol, .com, .ca, etc.), if the password is longer than 8 characters, and if the passwords match.